### PR TITLE
Update the config `base` in `vite.config.ts` to fix the absolute path issue in the application

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,7 @@ export default ({ command }: ConfigEnv): UserConfig => {
   // PROD
   return {
     root: srcRoot,
-    base: `${__dirname}/src/out/`,
+    base: './',
     plugins: [react()],
     resolve: {
       alias: {


### PR DESCRIPTION
The paths of the resources are incorrect if the base is current `__dirname` appends with `/src/out/`. It will become the current build machine's absolute path.

For example, I'm building my app in GitHub Actions, and the paths of the resources in the released app are incorrect:

<img width="418" alt="image" src="https://user-images.githubusercontent.com/12215513/158015493-341833aa-2cb7-4505-b734-b878336484cf.png">

And my app can't run with such errors:

<img width="367" alt="image" src="https://user-images.githubusercontent.com/12215513/158015536-535d5780-a371-405b-b5b4-40734faf0335.png">

After my change, the paths are correct and my app can run.

<img width="384" alt="image" src="https://user-images.githubusercontent.com/12215513/158016137-854997ce-ba93-4ad4-9ff2-910e357951f7.png">
