### PR TITLE
Add `src/out/` to ignorePatterns in `.eslintrc`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,5 +60,5 @@
         },
         "import/core-modules": [ "electron", "electron-is-dev" ]
     },
-    "ignorePatterns": ["node_modules/", "dist/", "main/"]
+    "ignorePatterns": ["node_modules/", "dist/", "main/", "src/out/"]
 }


### PR DESCRIPTION
from: #32 

---

I made a modification to ignore the files generated by the build command in the linting process, as they were causing a slowdown. 

### execution time

```.shell
$ DEBUG=eslint* yarn lint
```

| before | after |
|--|--|
|`eslint:cli-engine Linting complete in: 70337ms`|`eslint:cli-engine Linting complete in: 2210ms`|